### PR TITLE
docs(int4): replace legacy llama mirror in examples

### DIFF
--- a/docs/docs/advanced/anymodel.md
+++ b/docs/docs/advanced/anymodel.md
@@ -31,13 +31,15 @@ dataset = InstructionDataset(dataset_path)
 
 To initialize the model, simply run the following 2 commands:
 ```python
-from xturing.models import GenericModel
+from xturing.models import GenericLoraModel
 
-model_path = 'aleksickx/llama-7b-hf'
+model_path = "Qwen/Qwen2.5-0.5B"
 
 model = GenericLoraModel(model_path)
 ```
 The _'model_path'_ can be a locally saved model and/or any model available on the HuggingFace's [Model Hub](https://huggingface.co/models).
+
+If you are following older notebooks that reference legacy `llama-7b-hf` mirrors, prefer current upstream checkpoints. Legacy mirrors can fail on newer `transformers` releases.
 
 To fine-tune the model on a dataset, we will use the default configuration for the fine-tuning.
 

--- a/examples/features/int4_finetuning/LLaMA_lora_int4.ipynb
+++ b/examples/features/int4_finetuning/LLaMA_lora_int4.ipynb
@@ -63,7 +63,7 @@
     "\n",
     "instruction_dataset = InstructionDataset(\"../../models/llama/alpaca_data\")\n",
     "# Initializes the model\n",
-    "model = GenericLoraKbitModel('aleksickx/llama-7b-hf')"
+    "model = GenericLoraKbitModel('Qwen/Qwen2.5-0.5B')"
    ]
   },
   {

--- a/examples/features/int4_finetuning/README.md
+++ b/examples/features/int4_finetuning/README.md
@@ -91,7 +91,7 @@ You are encouraged to submit your performance results on other GPUs/configs/mode
 
 ## 📚 Tutorial
 
-All instructions are inside the example [notebook](LLaMA_lora_int4.ipynb). **_Special Note:_** Using this demo requires you to have appropriate access to LLaMA weights. To apply access to it through this [link](https://docs.google.com/forms/d/e/1FAIpQLSfqNECQnMkycAp2jP4Z9TFX0cGR4uf7b_fBxjY_OjhJILlKGA/viewform).
+All instructions are inside the example [notebook](LLaMA_lora_int4.ipynb). **_Special Note:_** some older mirrored LLaMA checkpoints are no longer compatible with recent `transformers` versions. Use a currently maintained checkpoint path (for example `Qwen/Qwen2.5-0.5B`) in the notebook for reliable setup.
 
 <br>
 


### PR DESCRIPTION
Summary:
- Replaces the legacy aleksickx/llama-7b-hf example checkpoint with Qwen/Qwen2.5-0.5B in the INT4 notebook and advanced any-model docs.
- Adds compatibility guidance that legacy mirrored checkpoints can fail on newer transformers versions.
- Updates the INT4 README note to direct users to maintained checkpoints.

Validation:
- python -m json.tool examples/features/int4_finetuning/LLaMA_lora_int4.ipynb >/dev/null
- docs build was not run in this branch because docs dependencies are not installed in the ephemeral worktree environment.

Closes #287