### PR TITLE
fix(engines): replace dead LLaMA checkpoint mirrors

### DIFF
--- a/src/xturing/engines/llama_engine.py
+++ b/src/xturing/engines/llama_engine.py
@@ -14,7 +14,7 @@ class LLamaEngine(CausalEngine):
     config_name: str = "llama_engine"
 
     def __init__(self, weights_path: Optional[Union[str, Path]] = None):
-        model_name = "aleksickx/llama-7b-hf"
+        model_name = "huggyllama/llama-7b"
         model = LlamaForCausalLM.from_pretrained(model_name, torch_dtype=DEFAULT_DTYPE)
         tokenizer = LlamaTokenizer.from_pretrained(model_name, add_bos_token=False)
         tokenizer.pad_token = tokenizer.eos_token
@@ -31,7 +31,7 @@ class LlamaLoraEngine(CausalLoraEngine):
     config_name: str = "llama_lora_engine"
 
     def __init__(self, weights_path: Optional[Union[str, Path]] = None):
-        model_name = "aleksickx/llama-7b-hf"
+        model_name = "huggyllama/llama-7b"
         model = LlamaForCausalLM.from_pretrained(
             model_name,
             torch_dtype=DEFAULT_DTYPE,
@@ -52,7 +52,7 @@ class LLamaInt8Engine(CausalEngine):
     config_name: str = "llama_int8_engine"
 
     def __init__(self, weights_path: Optional[Union[str, Path]] = None):
-        model_name = "aleksickx/llama-7b-hf"
+        model_name = "huggyllama/llama-7b"
         device_map = {"": int(os.environ.get("LOCAL_RANK") or 0)}
         model = LlamaForCausalLM.from_pretrained(
             model_name,
@@ -78,7 +78,7 @@ class LlamaLoraInt8Engine(CausalLoraEngine):
     config_name: str = "llama_lora_int8_engine"
 
     def __init__(self, weights_path: Optional[Union[str, Path]] = None):
-        model_name = "aleksickx/llama-7b-hf"
+        model_name = "huggyllama/llama-7b"
         device_map = {"": int(os.environ.get("LOCAL_RANK") or 0)}
         model = LlamaForCausalLM.from_pretrained(
             model_name,
@@ -118,7 +118,7 @@ class LlamaLoraKbitEngine(CausalLoraKbitEngine):
     config_name: str = "llama_lora_kbit_engine"
 
     def __init__(self, weights_path: Optional[Union[str, Path]] = None):
-        model_name = "decapoda-research/llama-7b-hf"
+        model_name = "huggyllama/llama-7b"
 
         tokenizer = LlamaTokenizer.from_pretrained(model_name, add_bos_token=False)
         tokenizer.pad_token = tokenizer.eos_token

--- a/src/xturing/engines/quant_utils/cachedistillationoutputs.py
+++ b/src/xturing/engines/quant_utils/cachedistillationoutputs.py
@@ -51,7 +51,7 @@ def cache_distillation_outputs(
 
 
 if __name__ == "__main__":
-    base_model = "decapoda-research/llama-7b-hf"
+    base_model = "huggyllama/llama-7b"
     seqlen = 2048
     n_samples = 10000
     train_cache_dir = ...  ###ANONYMIZED###

--- a/src/xturing/engines/quant_utils/lrec.py
+++ b/src/xturing/engines/quant_utils/lrec.py
@@ -20,7 +20,7 @@ def parse_args():
     parser.add_argument(
         "--base_model",
         type=str,
-        default="decapoda-research/llama-7b-hf",
+        default="huggyllama/llama-7b",
         help="The base model.",
     )
     parser.add_argument(


### PR DESCRIPTION
### Summary

The LLaMA engines hardcode two unofficial checkpoint mirrors that are no longer usable:

- **`decapoda-research/llama-7b-hf` — returns HTTP 401.** `LlamaLoraKbitEngine` (`llama_lora_kbit`) cannot load at all. Also the default for `--base_model` in `quant_utils/lrec.py` and `quant_utils/cachedistillationoutputs.py`.
- **`aleksickx/llama-7b-hf` — resolves, but is broken.** Its `tokenizer_config.json` is `{"bos_token": "", "eos_token": "", "unk_token": "", ...}` and the repo ships no fast `tokenizer.json`. Empty special tokens are what triggers the `RecursionError` reported in #287 (see huggingface/transformers#22762). It also silently corrupts the next two lines of engine code, which do `pad_token = eos_token` — i.e. `""`. It has 35 downloads.

All five `llama_engine.py` references plus the two `quant_utils` defaults now point at **`huggyllama/llama-7b`**: the same LLaMA-7B weights, public and ungated, with valid `bos`/`eos`/`unk` tokens and a fast `tokenizer.json`. 225k downloads.

This is a mirror swap, not a model change — `BaseModel.create("llama")` returns the same weights, from a host that works.

### Checklist

- [x] Tested — `pre-commit` (isort/black/autoflake) passes; checkpoint availability and tokenizer configs verified against the HF API
- [ ] Not tested — no live 7B download/fine-tune was run; needs a GPU box to confirm end-to-end

### Additional Information

Complements #338, which fixes the same legacy mirror in the docs and INT4 notebook. This PR covers the library code that #338 deliberately left alone.

`llama2_engine.py` uses `daryl149/llama-2-7b-chat-hf`, which was checked and is **not** affected — it has a fast tokenizer and valid special tokens. Left unchanged.