### PR TITLE
fix(model_apis): guard optional cohere and openai imports

### DIFF
--- a/src/xturing/model_apis/cohere.py
+++ b/src/xturing/model_apis/cohere.py
@@ -1,7 +1,16 @@
 import time
 from datetime import datetime
+from importlib import import_module
 
-import cohere
+try:
+    import cohere
+except ImportError as import_err:  # pragma: no cover - optional dependency
+    cohere = None
+    CohereError = Exception
+    _COHERE_IMPORT_ERROR = import_err
+else:  # pragma: no cover - dependency import paths exercised in runtime envs
+    CohereError = getattr(cohere, "CohereError", Exception)
+    _COHERE_IMPORT_ERROR = None
 
 from xturing.model_apis.base import TextGenerationAPI
 
@@ -10,7 +19,20 @@ class CohereTextGenerationAPI(TextGenerationAPI):
     config_name = "cohere"
 
     def __init__(self, engine, api_key):
+        self._ensure_dependency()
         super().__init__(engine, api_key=api_key, request_batch_size=1)
+
+    @staticmethod
+    def _ensure_dependency():
+        # Resolve from the currently loaded module to stay correct across reloads.
+        module = import_module(__name__)
+        cohere_module = getattr(module, "cohere", None)
+        if cohere_module is None:
+            raise ModuleNotFoundError(
+                "The cohere SDK is required for CohereTextGenerationAPI. "
+                "Install it with `pip install cohere`."
+            ) from getattr(module, "_COHERE_IMPORT_ERROR", None)
+        return cohere_module
 
     def generate_text(
         self,
@@ -40,7 +62,7 @@ class CohereTextGenerationAPI(TextGenerationAPI):
                     stop_sequences=stop_sequences,
                 )
                 break
-            except cohere.CohereError as e:
+            except CohereError as e:
                 print(f"CohereError: {e}.")
                 print(f"Retrying in {backoff_time} seconds...")
                 time.sleep(backoff_time)

--- a/src/xturing/model_apis/openai.py
+++ b/src/xturing/model_apis/openai.py
@@ -1,7 +1,21 @@
 import time
 from datetime import datetime
+from importlib import import_module
 
-import openai
+try:
+    import openai
+except ImportError as import_err:  # pragma: no cover - optional dependency
+    openai = None
+    OpenAIError = Exception
+    _OPENAI_IMPORT_ERROR = import_err
+else:  # pragma: no cover - dependency import paths exercised in runtime envs
+    # `openai.error` is the 0.x layout; 1.x exposes OpenAIError at the top level.
+    OpenAIError = getattr(
+        getattr(openai, "error", None),
+        "OpenAIError",
+        getattr(openai, "OpenAIError", Exception),
+    )
+    _OPENAI_IMPORT_ERROR = None
 
 from xturing.model_apis.base import TextGenerationAPI
 
@@ -10,6 +24,7 @@ class OpenAITextGenerationAPI(TextGenerationAPI):
     config_name = "openai"
 
     def __init__(self, engine, api_key, organization, request_batch_size=10):
+        self._ensure_dependency()
         super().__init__(
             engine=engine,
             api_key=api_key,
@@ -21,6 +36,18 @@ class OpenAITextGenerationAPI(TextGenerationAPI):
         if organization is not None:
             openai.organization = organization
         self.request_batch_size = request_batch_size
+
+    @staticmethod
+    def _ensure_dependency():
+        # Resolve from the currently loaded module to stay correct across reloads.
+        module = import_module(__name__)
+        openai_module = getattr(module, "openai", None)
+        if openai_module is None:
+            raise ModuleNotFoundError(
+                "The openai SDK is required for OpenAITextGenerationAPI. "
+                "Install it with `pip install openai`."
+            ) from getattr(module, "_OPENAI_IMPORT_ERROR", None)
+        return openai_module
 
     def get_completion(
         self,
@@ -86,7 +113,7 @@ class OpenAITextGenerationAPI(TextGenerationAPI):
                     best_of=best_of,
                 )
                 break
-            except openai.error.OpenAIError as e:
+            except OpenAIError as e:
                 print(f"OpenAIError: {e}.")
                 if "Please reduce your prompt" in str(e):
                     target_length = int(target_length * 0.8)

--- a/tests/xturing/model_apis/test_optional_sdk_guards.py
+++ b/tests/xturing/model_apis/test_optional_sdk_guards.py
@@ -1,0 +1,37 @@
+"""The optional SDK wrappers must import without their SDK installed.
+
+`xturing.model_apis` is imported transitively by `xturing.datasets`, so a bare
+top-level `import cohere` / `import openai` makes the whole package
+unimportable in environments where those SDKs are absent.
+"""
+
+import pytest
+
+
+def test_cohere_module_imports_without_sdk():
+    module = pytest.importorskip("xturing.model_apis.cohere")
+    # Bound at import time, so the retry loop's except clause stays valid.
+    assert hasattr(module, "CohereError")
+    assert issubclass(module.CohereError, BaseException)
+
+
+def test_openai_module_imports_without_sdk():
+    module = pytest.importorskip("xturing.model_apis.openai")
+    assert hasattr(module, "OpenAIError")
+    assert issubclass(module.OpenAIError, BaseException)
+
+
+def test_cohere_api_reports_missing_sdk(monkeypatch):
+    from xturing.model_apis.cohere import CohereTextGenerationAPI
+
+    monkeypatch.setattr("xturing.model_apis.cohere.cohere", None)
+    with pytest.raises(ModuleNotFoundError, match="pip install cohere"):
+        CohereTextGenerationAPI("medium", "fake-key")
+
+
+def test_openai_api_reports_missing_sdk(monkeypatch):
+    from xturing.model_apis.openai import OpenAITextGenerationAPI
+
+    monkeypatch.setattr("xturing.model_apis.openai.openai", None)
+    with pytest.raises(ModuleNotFoundError, match="pip install openai"):
+        OpenAITextGenerationAPI("davinci", "fake-key", None)


### PR DESCRIPTION
### Summary

`cohere.py` and `openai.py` import their SDKs at module scope. Because `xturing.model_apis` is imported transitively by `xturing.datasets.instruction_dataset`, a missing SDK makes the whole package unimportable.

Both are declared dependencies in `pyproject.toml` today, so **this is defensive hardening rather than a live break** for standard installs. It matters for lean CI jobs, partial installs, and vendored subsets — and it applies the pattern `ClaudeTextGenerationAPI` already uses for `anthropic` (itself also a declared dependency).

Changes, mirroring `claude.py`:
- Guard both imports; bind the SDK error classes at import time so the retry loops' `except` clauses remain valid when the module object is `None`.
- Gate construction via `_ensure_dependency()` with an actionable install message.

### Latent bug fixed

`except openai.error.OpenAIError` raises `AttributeError` on openai 1.x, which `openai >= 0.27.0` permits — the retry loop would crash instead of retrying. `OpenAIError` now resolves via the 0.x `openai.error` layout, falling back to the 1.x top-level class, then `Exception`.

### Checklist

- [x] Tested — verified both directions locally: package imports with `cohere`/`openai`/`anthropic` genuinely absent and construction raises `ModuleNotFoundError`; with the SDKs present, construction succeeds and the error classes bind to the real SDK types (including the 1.x layout).
- [x] Documented — module docstring in the new test file explains the import chain.

### Note on CI

These tests will **not** run in CI. `lightweight-tests` installs only `pytest fastapi uvicorn httpx` and runs just `test_api_server.py` and `test_runner.py`. Widening that job is a worthwhile separate change — it is the same gap that let a transformers-5-only symbol through with four green checks in #318.