### PR TITLE
ci: run the model_apis test suite (and repair it)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,33 @@ jobs:
         run: |
           PYTHONPATH=src pytest -q tests/xturing/cli/test_api_server.py tests/xturing/evaluation/test_runner.py
 
+  model-api-tests:
+    # Covers tests/xturing/model_apis/, which lightweight-tests cannot reach:
+    # that job installs no SDKs, so importing xturing.model_apis fails there.
+    # These are the pure-Python API wrappers -- no model weights are downloaded.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+
+      - name: Install test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest
+          # CPU-only torch: xturing.model_apis imports it transitively and the
+          # default wheel pulls in a large CUDA stack this job never uses.
+          pip install torch --index-url https://download.pytorch.org/whl/cpu
+          pip install anthropic cohere openai
+
+      - name: Run model API tests
+        run: |
+          PYTHONPATH=src pytest -q tests/xturing/model_apis/
+
   docs-build:
     runs-on: ubuntu-latest
     defaults:

--- a/tests/xturing/model_apis/test_claude_api.py
+++ b/tests/xturing/model_apis/test_claude_api.py
@@ -4,9 +4,21 @@ import pytest
 
 
 def _build_anthropic_error(error_cls, message):
+    """Build an SDK error instance that `except error_cls` still catches.
+
+    The anthropic SDK's error signatures differ across releases (APIError takes
+    `request`, RateLimitError takes `response`), so constructing them directly
+    ties the suite to one version. Subclassing with a permissive __init__ keeps
+    the isinstance relationship without depending on the signature.
+    """
     if error_cls is Exception:
         return Exception(message)
-    return error_cls(message, response=None, body=None)
+    stub_cls = type(
+        f"Stub{error_cls.__name__}",
+        (error_cls,),
+        {"__init__": lambda self, msg: Exception.__init__(self, msg)},
+    )
+    return stub_cls(message)
 
 
 class TestClaudeTextGenerationAPI:


### PR DESCRIPTION
### Summary

`tests/xturing/model_apis/` has **never executed in CI**. `lightweight-tests` installs only `pytest fastapi uvicorn httpx` and runs exactly two files:

```
pytest -q tests/xturing/cli/test_api_server.py tests/xturing/evaluation/test_runner.py
```

Two consequences showed up while reviewing recent PRs:

1. **`test_claude_api.py` was already failing.** Running it surfaces 2 real failures on `main` — `APIError.__init__() got an unexpected keyword argument 'response'`. The helper passed `response=`/`body=` to every anthropic error class, but the signatures diverge (`APIError` takes `request`, `RateLimitError` takes `response`), so the suite only ever worked against one SDK release.
2. **A transformers-5-only import passed four green checks** in #318, because nothing imported the module it lived in.

### Changes

- **`test_claude_api.py`** — build SDK errors by subclassing with a permissive `__init__` instead of calling the version-specific constructor. The instance is still caught by `except error_cls`, without pinning the suite to one anthropic release.
- **`.github/workflows/ci.yml`** — new `model-api-tests` job running `tests/xturing/model_apis/`.

Added as a **separate job** rather than widening `lightweight-tests`, so the existing required check keeps its current scope and runtime.

These wrappers are pure Python — **no model weights are downloaded**. torch comes from the CPU index because `xturing.model_apis` imports it transitively and the default wheel pulls a large CUDA stack this job never uses.

### Verification

Against a clean venv (`pytest` + CPU torch + `anthropic`/`cohere`/`openai`):

- `main`: **13 passed** (2 of which fail without the helper fix)
- `glenn/qwen3omni` (#318): its 6 Qwen3-Omni tests **pass** in the same environment — including the import-guard tests, which exercise the missing-symbol path

### What this does *not* cover

`tests/xturing/models/`, `datasets/`, `preprocessors/`, and `trainers/` still don't run. Those need the full stack and, in several cases, download model weights (`BaseModel.create("gpt2")` at import time). Worth a follow-up, but it is a different cost profile and belongs in its own change.

### Checklist

- [x] Tested — exact CI command reproduced locally on two branches
- [x] Documented — job carries a comment explaining why it exists and why torch is CPU-only