### PR TITLE
docs(contributing): drop dead AGENTS.md link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,6 @@
 
 We welcome and appreciate contributions to xTuring! Whether it's a bug fix, a new feature, or simply a typo, every little bit helps.
 
-Before starting, please skim the [Repository Guidelines](AGENTS.md) for project structure, local commands, style, and testing conventions.
 For the active modernization scope, see the [2026 milestone roadmap](docs/docs/contributing/milestone_2026.md).
 
 ## Getting Started


### PR DESCRIPTION
### Summary

`CONTRIBUTING.md` line 5 pointed contributors at `AGENTS.md`:

> Before starting, please skim the [Repository Guidelines](AGENTS.md) for project structure, local commands, style, and testing conventions.

**`AGENTS.md` is not tracked in this repository and never has been on `main`.** The link 404s for everyone reading the contributing guide.

It also conflicts with #318, which adds `AGENTS.md` and `CLAUDE.md` to `.gitignore` — leaving `CONTRIBUTING.md` pointing at a file the repo is explicitly configured never to track.

Removing the reference rather than committing the file. The 2026 milestone link on the following line is unaffected and verified to resolve.

### Checklist

- [x] Tested — confirmed no remaining `AGENTS.md` references in tracked files; `pre-commit` passes
- [x] Documented — n/a, this is the docs fix