### PR TITLE
ci(deps): add dependabot config with grouped docs lockfile updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+
+updates:
+  # Docs site (Docusaurus). Everything here is devDependencies of a
+  # `private: true` package that is never published, so these bumps are
+  # build-time only and do not reach users of the Python package.
+  #
+  # Grouped deliberately: ungrouped, Dependabot opens one PR per package
+  # against a single 30k-line lockfile. They conflict with each other and
+  # with any hand-written lockfile work, and each merge forces a rebase of
+  # the rest. One grouped PR per week keeps the lockfile serialized.
+  - package-ecosystem: "npm"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 3
+    groups:
+      docs-npm:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "build(deps)"
+    labels:
+      - "dependencies"
+      - "docs"
+
+  # GitHub Actions used by .github/workflows/. Low volume; grouped so a
+  # week's action bumps land as one PR.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "dependencies"
+      - "ci"


### PR DESCRIPTION
### Why

There is no `.github/dependabot.yml` in the repo, so Dependabot has been running on defaults: **one PR per package** against a single ~30k-line `docs/package-lock.json`.

That produced the mess untangled today — twelve open docs PRs that conflicted with each other and with the hand-written lockfile refresh in #342. Each merge put the rest `BEHIND`, and three (#353, #354, #355) turned out to be no-ops by the time they were looked at, because #342 had already carried their target versions.

### What this does

- Groups all `/docs` npm **minor + patch** bumps into **one PR per week** (Mondays), so the lockfile is rewritten once per cycle instead of once per package.
- Caps concurrent docs PRs at 3.
- Leaves **majors ungrouped**, so a breaking bump still gets its own PR and its own review.
- Groups `github-actions` bumps too — low volume, but same reasoning.
- Sets `build(deps)` / `ci(deps)` commit prefixes to match existing history, and adds `dependencies` labels.

### Scope note

`docs/package.json` is `private: true` and never published, so everything grouped here is build-time only and never reaches users of the Python package. That's what makes weekly batching the right tradeoff rather than per-package immediacy.

Validated: the YAML parses and both ecosystem entries resolve as expected.