### PR TITLE
docs(readme): correct the transformers 5.x note

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ Why xTuring:
 ```bash
 pip install xturing
 ```
-Note: Qwen3-Omni is optional and requires `transformers>=5.0.0`, which provides `AutoModelForMultimodalLM`. The rest of xTuring works on `transformers>=4.36.0`; note that 5.x drops the `load_in_8bit`/`load_in_4bit` loading kwargs used by the INT8/INT4 engines.
+Note: xTuring requires `transformers>=4.36.0`. Do not upgrade to `transformers` 5.x yet — 5.x drops the `load_in_8bit`/`load_in_4bit` loading kwargs that the INT8/INT4 engines rely on, and nothing currently shipped needs 5.x.
+
+Qwen3-Omni support (which requires `transformers>=5.0.0`) is not released yet — see [#318](https://github.com/stochasticai/xTuring/pull/318).
 
 <br>
 


### PR DESCRIPTION
### Why

#320 added an install note describing Qwen3-Omni's `transformers>=5.0.0` requirement. Two problems: that feature isn't merged (#318 is still open, now parked), and `pyproject.toml:46` pins `transformers>=4.36.0`. So `main` documented the requirements of something it doesn't ship — and the note read as an invitation to upgrade, which would break the user's install for no benefit.

### The upgrade really is breaking — verified

Checked against the actual `transformers` v5.16.1 source tree, not from memory:

- `load_in_8bit=` / `load_in_4bit=` were **hard-removed** from `from_pretrained` in v5.0.0 ([PR #41287](https://github.com/huggingface/transformers/pull/41287)), not deprecated. `grep` for them in `modeling_utils.py` at v5.16.1 returns zero hits.
- The failure is a bare `TypeError: __init__() got an unexpected keyword argument 'load_in_8bit'` — there is no friendly "use `quantization_config` instead" error.
- xturing passes them as bare kwargs in **7 places**: `engines/causal.py` (50, 94, 251), `llama_engine.py` (60, 86), `gptj_engine.py` (46, 66).

So the warning in this note is accurate, not precautionary.

### What changed

Inverts the note: states the supported floor, warns against 5.x with the concrete reason, and points at #318 for Qwen3-Omni rather than implying it's available today.

This is documentation only — no code or dependency changes. The actual 5.x migration is tracked separately on #318.