### PR TITLE
fix(docs): use the prism-react-renderer 2.x themes API

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -1,8 +1,9 @@
 // @ts-check
 // Note: type annotations allow type checking and IDEs autocompletion
 
-const lightCodeTheme = require('prism-react-renderer/themes/github');
-const darkCodeTheme = require('prism-react-renderer/themes/dracula');
+const { themes: prismThemes } = require('prism-react-renderer');
+const lightCodeTheme = prismThemes.github;
+const darkCodeTheme = prismThemes.dracula;
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {


### PR DESCRIPTION
The weekly dependency bump (#363) moved prism-react-renderer from 1.x to 2.x, which dropped the per-theme entry points. `docusaurus.config.js` still required `prism-react-renderer/themes/github` and `.../dracula`, so the docs build fails on main with MODULE_NOT_FOUND. This imports the `themes` export instead, as Docusaurus 3 does.

Verified locally: `npm ci && npm run build` in `docs/` succeeds.